### PR TITLE
Fix to not use template.Must()

### DIFF
--- a/cmd/build-ecschedule/main.go
+++ b/cmd/build-ecschedule/main.go
@@ -106,7 +106,10 @@ func buildECSchedule(c *cli.Context) error {
 	var b bytes.Buffer
 	b.Grow(len(tpl)*len(rules) + len(prefixTemplate))
 
-	pt := template.Must(template.New("template").Parse(string(prefixTemplate)))
+	pt, err := template.New("template").Parse(prefixTemplate)
+	if err != nil {
+		return fmt.Errorf("template.New(template).Parse() failed: %w", err)
+	}
 
 	pf := prefix{
 		Region:  c.String("region"),
@@ -117,7 +120,10 @@ func buildECSchedule(c *cli.Context) error {
 		return fmt.Errorf("t.Execute(prefix) failed:  %w", err)
 	}
 
-	t := template.Must(template.New("rule").Parse(string(tpl)))
+	t, err := template.New("rule").Parse(string(tpl))
+	if err != nil {
+		return fmt.Errorf("template.New(rule).Parse() failed: %w", err)
+	}
 
 	env := c.String("environment")
 


### PR DESCRIPTION
template が間違っていたときに panic するよりもエラーを返した方が適当かなと思いました。

make したときテンプレートが間違っているときはこんな感じになります。
```
$ make build_ecschedule
/Users/ikawaha/go/bin/build-ecschedule --rules config/ecschedule.rules.yaml --template config/devonaws/ecschedule.rule.yaml.template   --environment devonaws   --cluster partner-devonaws   --output config/devonaws/ecschedule.yaml
/Users/ikawaha/go/bin/build-ecschedule --rules config/ecschedule.rules.yaml --template config/production/ecschedule.rule.yaml.template --environment production --cluster partner-production --output config/production/ecschedule.yaml
2022/03/25 14:05:05 template.New(rule).Parse() failed: template: rule:12: function "must_env" not defined
make: *** [build_ecschedule] Error 1
```