### PR TITLE
feat: rules を 24h ガントチャート(HTML)で可視化する gantt サブコマンド

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build-ecschedule
+*.html

--- a/README.md
+++ b/README.md
@@ -8,3 +8,24 @@ build-ecschedule is a tool to build ecschedule.yaml ([Songmu/ecschedule: ecsched
 % go install github.com/pacificporter/build-ecschedule/cmd/build-ecschedule@latest
 % build-ecschedule --rules sample/ecschedule.rules.yaml --template sample/ecschedule.rule.yaml.template --environment production --cluster tokyo-production --output ecschedule.yaml
 ```
+
+## gantt
+
+`gantt` サブコマンドは rules.yaml を「1 日 24 時間のガントチャート」として HTML に可視化します。どのバッチがいつ実行されるかを俯瞰できます。
+
+```console
+% build-ecschedule gantt --rules sample/ecschedule.rules.yaml --output ecschedule-gantt.html
+```
+
+- cron 式は AWS EventBridge 形式(UTC)としてパースし、表示は `--offset`(デフォルト 9 = JST)で変換します。
+- 各行はバーにホバーすると cron / command / 実行時刻 / 日・曜日などの条件を表示します。
+- 行は実行開始時刻順に並びます。`--sort file` で rules.yaml の記述順になります。
+- バーの色は command のバイナリ名ごとに割り当てます。
+
+| flag | default | 説明 |
+|------|---------|------|
+| `--rules` | (必須) | rules YAML ファイル |
+| `--output` | `ecschedule-gantt.html` | 出力 HTML ファイル |
+| `--offset` | `9` | UTC からのオフセット時間(JST=9) |
+| `--tz` | `JST` | 表示用タイムゾーンラベル |
+| `--sort` | `time` | 行の並び順(`time` = 実行開始時刻順 / `file` = 記述順) |

--- a/cmd/build-ecschedule/gantt.go
+++ b/cmd/build-ecschedule/gantt.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/urfave/cli/v2"
+)
+
+// ganttCommand は rules.yaml を 1 日 24 時間のガントチャート(HTML)として可視化する。
+// cron 式は AWS EventBridge 形式(UTC)としてパースし、表示はタイムゾーンオフセット
+// (デフォルト JST = +9)に変換する。
+var ganttCommand = &cli.Command{
+	Name:   "gantt",
+	Usage:  "render rules.yaml as a 24h gantt chart (HTML)",
+	Action: runGantt,
+	Flags: []cli.Flag{
+		&cli.PathFlag{Name: "rules", Required: true, Usage: "rules YAML file"},
+		&cli.PathFlag{Name: "output", Value: "ecschedule-gantt.html", Usage: "output HTML file"},
+		&cli.IntFlag{Name: "offset", Value: 9, Usage: "timezone offset in hours from UTC (JST=9)"},
+		&cli.StringFlag{Name: "tz", Value: "JST", Usage: "timezone label for display"},
+		&cli.StringFlag{Name: "sort", Value: "time", Usage: "row order: time (first fired time) or file (rules order)"},
+	},
+}
+
+func runGantt(c *cli.Context) error {
+	rulesBs, err := os.ReadFile(c.Path("rules"))
+	if err != nil {
+		return fmt.Errorf("os.ReadFile(%s) failed: %w", c.Path("rules"), err)
+	}
+	var rules []Rule
+	if err := yaml.Unmarshal(rulesBs, &rules); err != nil {
+		return fmt.Errorf("yaml.Unmarshal(rules) failed: %w", err)
+	}
+
+	offsetMin := c.Int("offset") * 60
+	rows := make([]ganttRow, 0, len(rules))
+	for _, r := range rules {
+		r.Name = strings.TrimSpace(r.Name)
+		r.Description = strings.TrimSpace(r.Description)
+		r.ScheduleExpression = strings.TrimSpace(r.ScheduleExpression)
+		r.Command = strings.TrimSpace(r.Command)
+
+		cron, perr := parseCron(r.ScheduleExpression)
+		if perr != nil {
+			return fmt.Errorf("parseCron(%q) for rule %q failed: %w", r.ScheduleExpression, r.Name, perr)
+		}
+		minutes := cron.firedMinutes(offsetMin)
+		rows = append(rows, ganttRow{
+			rule:    r,
+			cron:    cron,
+			group:   commandBinary(r.Command),
+			minutes: minutes,
+			runs:    mergeRuns(minutes),
+		})
+	}
+
+	if c.String("sort") != "file" {
+		sort.SliceStable(rows, func(i, j int) bool {
+			fi, fj := firstOr(rows[i].minutes, 1<<30), firstOr(rows[j].minutes, 1<<30)
+			if fi != fj {
+				return fi < fj
+			}
+			return rows[i].rule.Name < rows[j].rule.Name
+		})
+	}
+
+	out := renderHTML(rows, c.Int("offset"), c.String("tz"))
+	if err := os.WriteFile(c.Path("output"), []byte(out), 0600); err != nil {
+		return fmt.Errorf("os.WriteFile(%s) failed: %w", c.Path("output"), err)
+	}
+	fmt.Printf("wrote %s (%d rules)\n", c.Path("output"), len(rows))
+	return nil
+}
+
+type ganttRow struct {
+	rule    Rule
+	cron    cronExpr
+	group   string
+	minutes []int    // 発火する分(JST, 0..1439)昇順・重複なし
+	runs    [][2]int // 連続区間 [start, end)(0..1440)
+}
+
+// ---- cron parsing -----------------------------------------------------------
+
+// cronExpr は AWS EventBridge の cron(分 時 日 月 曜日 年)を保持する。
+type cronExpr struct {
+	minute, hour, dom, month, dow, year string
+}
+
+func parseCron(expr string) (cronExpr, error) {
+	s := strings.TrimSpace(expr)
+	if !strings.HasPrefix(s, "cron(") || !strings.HasSuffix(s, ")") {
+		return cronExpr{}, fmt.Errorf("not a cron() expression")
+	}
+	body := strings.TrimSuffix(strings.TrimPrefix(s, "cron("), ")")
+	f := strings.Fields(body)
+	if len(f) != 6 {
+		return cronExpr{}, fmt.Errorf("expected 6 fields, got %d", len(f))
+	}
+	return cronExpr{minute: f[0], hour: f[1], dom: f[2], month: f[3], dow: f[4], year: f[5]}, nil
+}
+
+// firedMinutes は 1 日の発火時刻(分単位)を、タイムゾーンオフセットを足した表示時刻
+// (0..1439, 翌日へ回り込む場合は剰余)として返す。日・月・曜日の制約は時刻には影響
+// しないため、ここでは分・時のみ展開する。
+func (e cronExpr) firedMinutes(offsetMin int) []int {
+	minutes := expandField(e.minute, 0, 59)
+	hours := expandField(e.hour, 0, 23)
+	set := make(map[int]bool, len(minutes)*len(hours))
+	for _, h := range hours {
+		for _, m := range minutes {
+			t := ((h*60+m+offsetMin)%1440 + 1440) % 1440
+			set[t] = true
+		}
+	}
+	out := make([]int, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// expandField は cron の 1 フィールドを [min, max] の範囲で数値展開する。
+// 対応: *, ?, a, a-b, a-b/step, */step, a,b,c, および a>b の巻き戻し範囲。
+// L など数値以外のトークンは時刻計算では無視する(制約表示で別途扱う)。
+func expandField(field string, min, max int) []int {
+	field = strings.TrimSpace(field)
+	if field == "*" || field == "?" || field == "" {
+		return rangeInts(min, max, 1)
+	}
+	set := map[int]bool{}
+	for _, part := range strings.Split(field, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		step := 1
+		if i := strings.Index(part, "/"); i >= 0 {
+			if s, err := strconv.Atoi(strings.TrimSpace(part[i+1:])); err == nil && s > 0 {
+				step = s
+			}
+			part = strings.TrimSpace(part[:i])
+		}
+		var lo, hi int
+		switch {
+		case part == "*" || part == "?":
+			lo, hi = min, max
+		case strings.Contains(part, "-"):
+			seg := strings.SplitN(part, "-", 2)
+			a, err1 := strconv.Atoi(strings.TrimSpace(seg[0]))
+			b, err2 := strconv.Atoi(strings.TrimSpace(seg[1]))
+			if err1 != nil || err2 != nil {
+				continue
+			}
+			lo, hi = a, b
+		default:
+			v, err := strconv.Atoi(part)
+			if err != nil {
+				continue // L などは無視
+			}
+			lo, hi = v, v
+		}
+		if lo <= hi {
+			for v := lo; v <= hi; v += step {
+				if v >= min && v <= max {
+					set[v] = true
+				}
+			}
+		} else {
+			// 巻き戻し範囲(例: 時の 22-14)
+			for v := lo; v <= max; v += step {
+				set[v] = true
+			}
+			for v := min; v <= hi; v += step {
+				set[v] = true
+			}
+		}
+	}
+	out := make([]int, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func rangeInts(min, max, step int) []int {
+	out := make([]int, 0, (max-min)/step+1)
+	for v := min; v <= max; v += step {
+		out = append(out, v)
+	}
+	return out
+}
+
+// ---- summaries --------------------------------------------------------------
+
+var jpWeekday = map[int]string{1: "日", 2: "月", 3: "火", 4: "水", 5: "木", 6: "金", 7: "土"}
+
+// constraintText は日・月・曜日フィールドから人間可読の実行条件を組み立てる。
+// 注意: EventBridge は日付境界を UTC で評価するため、表示時刻(JST)と曜日がずれる
+// 場合がある。ここでは cron に書かれた値をそのまま示す。
+func (e cronExpr) constraintText() string {
+	var parts []string
+
+	if !isWild(e.dow) {
+		days := expandField(e.dow, 1, 7)
+		names := make([]string, 0, len(days))
+		for _, d := range days {
+			if n, ok := jpWeekday[d]; ok {
+				names = append(names, n)
+			}
+		}
+		if len(names) > 0 {
+			parts = append(parts, fmt.Sprintf("曜日: %s (UTC基準)", strings.Join(names, "・")))
+		}
+	}
+	if !isWild(e.dom) {
+		parts = append(parts, fmt.Sprintf("日: %s", e.dom))
+	}
+	if !isWild(e.month) {
+		parts = append(parts, fmt.Sprintf("月: %s", e.month))
+	}
+	if len(parts) == 0 {
+		return "毎日"
+	}
+	return strings.Join(parts, " / ")
+}
+
+func isWild(f string) bool {
+	f = strings.TrimSpace(f)
+	return f == "*" || f == "?" || f == ""
+}
+
+// timesText は発火時刻の要約を返す。少数なら HH:MM を列挙し、多い場合は回数で示す。
+func timesText(minutes []int) string {
+	if len(minutes) == 0 {
+		return "(なし)"
+	}
+	if len(minutes) >= 1440 {
+		return "毎分"
+	}
+	if len(minutes) <= 24 {
+		ss := make([]string, 0, len(minutes))
+		for _, m := range minutes {
+			ss = append(ss, fmt.Sprintf("%02d:%02d", m/60, m%60))
+		}
+		return strings.Join(ss, ", ")
+	}
+	return fmt.Sprintf("%d 回/日", len(minutes))
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func commandBinary(command string) string {
+	body := strings.TrimSpace(command)
+	body = strings.TrimPrefix(body, "[")
+	body = strings.TrimSuffix(body, "]")
+	for _, tok := range strings.Split(body, ",") {
+		tok = strings.TrimSpace(tok)
+		tok = strings.Trim(tok, "'\"")
+		if tok == "" {
+			continue
+		}
+		if i := strings.LastIndex(tok, "/"); i >= 0 {
+			tok = tok[i+1:]
+		}
+		return tok
+	}
+	return "(unknown)"
+}
+
+func mergeRuns(minutes []int) [][2]int {
+	var runs [][2]int
+	for _, m := range minutes {
+		if len(runs) > 0 && runs[len(runs)-1][1] == m {
+			runs[len(runs)-1][1] = m + 1
+			continue
+		}
+		runs = append(runs, [2]int{m, m + 1})
+	}
+	return runs
+}
+
+func firstOr(xs []int, dflt int) int {
+	if len(xs) == 0 {
+		return dflt
+	}
+	return xs[0]
+}
+
+// groupColor は binary 名から決定的に HSL の色相を割り当てる。
+func groupColor(group string) string {
+	var h uint32 = 2166136261
+	for i := 0; i < len(group); i++ {
+		h ^= uint32(group[i])
+		h *= 16777619
+	}
+	hue := int(h % 360)
+	return fmt.Sprintf("hsl(%d, 70%%, 45%%)", hue)
+}

--- a/cmd/build-ecschedule/gantt_html.go
+++ b/cmd/build-ecschedule/gantt_html.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"sort"
+	"strings"
+)
+
+func renderHTML(rows []ganttRow, offsetHours int, tz string) string {
+	var b strings.Builder
+
+	b.WriteString(`<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ecschedule gantt</title>
+<style>
+:root { --label-w: 320px; --row-h: 20px; }
+* { box-sizing: border-box; }
+body { margin: 0; font-family: -apple-system, "Helvetica Neue", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif; font-size: 12px; color: #222; }
+header { padding: 12px 16px; border-bottom: 1px solid #ddd; position: sticky; top: 0; background: #fff; z-index: 5; }
+header h1 { margin: 0 0 4px; font-size: 15px; }
+header .meta { color: #666; font-size: 11px; }
+.legend { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 4px 12px; }
+.legend span { display: inline-flex; align-items: center; gap: 4px; }
+.legend i { width: 11px; height: 11px; border-radius: 2px; display: inline-block; }
+.chart { padding: 0 16px 40px; }
+.axis { display: flex; position: sticky; top: var(--axis-top, 96px); background: #fff; z-index: 4; border-bottom: 1px solid #ccc; }
+.axis .label-pad { width: var(--label-w); flex: none; }
+.axis .ticks { position: relative; flex: 1; height: 20px; }
+.axis .ticks span { position: absolute; transform: translateX(-50%); color: #888; font-size: 10px; top: 4px; }
+.row { display: flex; align-items: center; height: var(--row-h); border-bottom: 1px solid #f2f2f2; }
+.row:hover { background: #f6fbff; }
+.row.disabled { opacity: .4; }
+.row .label { width: var(--label-w); flex: none; padding-right: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.row .label .desc { color: #999; margin-left: 6px; }
+.track { position: relative; flex: 1; height: 100%;
+  background-image: repeating-linear-gradient(to right, #eee 0 1px, transparent 1px calc(100% / 24)); }
+.track svg { display: block; width: 100%; height: 100%; }
+#tip { position: fixed; pointer-events: none; z-index: 10; max-width: 480px; display: none;
+  background: #222; color: #fff; padding: 8px 10px; border-radius: 6px; font-size: 11px; line-height: 1.5; box-shadow: 0 2px 10px rgba(0,0,0,.3); }
+#tip b { color: #9ad; }
+#tip code { background: rgba(255,255,255,.12); padding: 1px 4px; border-radius: 3px; }
+</style>
+</head>
+<body>
+`)
+
+	// ヘッダー + 凡例
+	fmt.Fprintf(&b, "<header><h1>ecschedule 実行スケジュール</h1>")
+	fmt.Fprintf(&b, `<div class="meta">%d ルール / 横軸 = 1 日 24 時間(%s, UTC%+d)。バーにホバーで詳細。日・曜日制約は cron 上は UTC 基準。</div>`,
+		len(rows), html.EscapeString(tz), offsetHours)
+	b.WriteString(`<div class="legend">`)
+	for _, g := range legendGroups(rows) {
+		fmt.Fprintf(&b, `<span><i style="background:%s"></i>%s</span>`, groupColor(g), html.EscapeString(g))
+	}
+	b.WriteString(`</div></header>`)
+
+	b.WriteString(`<div class="chart">`)
+
+	// 時刻軸
+	b.WriteString(`<div class="axis"><div class="label-pad"></div><div class="ticks">`)
+	for h := 0; h <= 24; h += 2 {
+		left := float64(h) / 24.0 * 100.0
+		fmt.Fprintf(&b, `<span style="left:%.4f%%">%d</span>`, left, h)
+	}
+	b.WriteString(`</div></div>`)
+
+	// 各行
+	for _, r := range rows {
+		color := groupColor(r.group)
+		cls := "row"
+		if r.rule.Disabled {
+			cls += " disabled"
+		}
+		tip := buildTip(r, tz)
+		fmt.Fprintf(&b, `<div class="%s" data-tip="%s">`, cls, html.EscapeString(tip))
+		label := html.EscapeString(r.rule.Name)
+		if r.rule.Disabled {
+			label += " (disabled)"
+		}
+		fmt.Fprintf(&b, `<div class="label">%s<span class="desc">%s</span></div>`,
+			label, html.EscapeString(r.rule.Description))
+		b.WriteString(`<div class="track"><svg viewBox="0 0 1440 10" preserveAspectRatio="none">`)
+		for _, run := range r.runs {
+			w := run[1] - run[0]
+			// 細い区間も視認できるよう最小幅を確保
+			drawW := w
+			if drawW < 3 {
+				drawW = 3
+			}
+			fmt.Fprintf(&b, `<rect x="%d" y="0" width="%d" height="10" fill="%s"/>`, run[0], drawW, color)
+		}
+		b.WriteString(`</svg></div></div>`)
+	}
+
+	b.WriteString(`</div>`)
+
+	// ツールチップ + スクリプト
+	b.WriteString(`<div id="tip"></div>
+<script>
+(function(){
+  var tip = document.getElementById('tip');
+  document.querySelectorAll('.row').forEach(function(row){
+    row.addEventListener('mousemove', function(e){
+      tip.innerHTML = row.getAttribute('data-tip');
+      tip.style.display = 'block';
+      var x = e.clientX + 14, y = e.clientY + 14;
+      var r = tip.getBoundingClientRect();
+      if (x + r.width > window.innerWidth) x = e.clientX - r.width - 14;
+      if (y + r.height > window.innerHeight) y = e.clientY - r.height - 14;
+      tip.style.left = x + 'px';
+      tip.style.top = y + 'px';
+    });
+    row.addEventListener('mouseleave', function(){ tip.style.display = 'none'; });
+  });
+})();
+</script>
+</body>
+</html>
+`)
+
+	return b.String()
+}
+
+// buildTip はホバー時に表示する HTML 文字列(data-tip 属性に格納)を作る。
+func buildTip(r ganttRow, tz string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "<b>%s</b><br>", html.EscapeString(r.rule.Name))
+	if r.rule.Description != "" {
+		fmt.Fprintf(&b, "%s<br>", html.EscapeString(r.rule.Description))
+	}
+	fmt.Fprintf(&b, "<b>cron</b> <code>%s</code><br>", html.EscapeString(r.rule.ScheduleExpression))
+	fmt.Fprintf(&b, "<b>command</b> <code>%s</code><br>", html.EscapeString(r.rule.Command))
+	fmt.Fprintf(&b, "<b>実行時刻(%s)</b> %s<br>", html.EscapeString(tz), html.EscapeString(timesText(r.minutes)))
+	fmt.Fprintf(&b, "<b>条件</b> %s", html.EscapeString(r.cron.constraintText()))
+	if len(r.rule.Environment) > 0 {
+		fmt.Fprintf(&b, "<br><b>environment</b> %s", html.EscapeString(strings.Join(r.rule.Environment, ", ")))
+	}
+	if r.rule.Disabled {
+		b.WriteString("<br><b>disabled</b>")
+	}
+	return b.String()
+}
+
+func legendGroups(rows []ganttRow) []string {
+	seen := map[string]bool{}
+	var gs []string
+	for _, r := range rows {
+		if !seen[r.group] {
+			seen[r.group] = true
+			gs = append(gs, r.group)
+		}
+	}
+	sort.Strings(gs)
+	return gs
+}

--- a/cmd/build-ecschedule/gantt_html.go
+++ b/cmd/build-ecschedule/gantt_html.go
@@ -90,7 +90,12 @@ header .meta { color: #666; font-size: 11px; }
 			if drawW < 3 {
 				drawW = 3
 			}
-			fmt.Fprintf(&b, `<rect x="%d" y="0" width="%d" height="10" fill="%s"/>`, run[0], drawW, color)
+			// viewBox(0..1440)をはみ出さないよう、末尾付近では開始位置を左へ寄せる
+			x := run[0]
+			if x+drawW > 1440 {
+				x = 1440 - drawW
+			}
+			fmt.Fprintf(&b, `<rect x="%d" y="0" width="%d" height="10" fill="%s"/>`, x, drawW, color)
 		}
 		b.WriteString(`</svg></div></div>`)
 	}

--- a/cmd/build-ecschedule/main.go
+++ b/cmd/build-ecschedule/main.go
@@ -19,13 +19,18 @@ func main() {
 		Name:   "build-ecschedule",
 		Usage:  "a tool to build ecschedule.yaml (https://github.com/Songmu/ecschedule) from rules.yaml and template",
 		Action: buildECSchedule,
+		// NOTE: ここでは Required を付けない。Required な global flag は gantt 等の
+		// サブコマンド実行時にも強制されてしまうため、必須チェックは buildECSchedule 内で行う。
 		Flags: []cli.Flag{
-			&cli.PathFlag{Name: "rules", Required: true, Usage: "rules YAML file"},
+			&cli.PathFlag{Name: "rules", Usage: "rules YAML file"},
 			&cli.PathFlag{Name: "output", Value: "ecschedule.yaml", Usage: "output file"},
-			&cli.PathFlag{Name: "template", Required: true, Usage: "template file"},
+			&cli.PathFlag{Name: "template", Usage: "template file"},
 			&cli.StringFlag{Name: "region", Value: "ap-northeast-1", Usage: "aws region"},
-			&cli.StringFlag{Name: "cluster", Required: true, Usage: "AWS Cluster"},
+			&cli.StringFlag{Name: "cluster", Usage: "AWS Cluster"},
 			&cli.StringFlag{Name: "environment", Value: "sandbox", Usage: "environment"},
+		},
+		Commands: []*cli.Command{
+			ganttCommand,
 		},
 	}
 
@@ -89,6 +94,12 @@ func stringContains(ss []string, s string) bool {
 }
 
 func buildECSchedule(c *cli.Context) error {
+	for _, name := range []string{"rules", "template", "cluster"} {
+		if c.String(name) == "" {
+			return fmt.Errorf(`Required flag "%s" not set`, name)
+		}
+	}
+
 	rulesBs, err := os.ReadFile(c.Path("rules"))
 	if err != nil {
 		return fmt.Errorf("os.ReadFile(%s) failed: %w", c.Path("rules"), err)

--- a/cmd/build-ecschedule/main.go
+++ b/cmd/build-ecschedule/main.go
@@ -94,9 +94,18 @@ func stringContains(ss []string, s string) bool {
 }
 
 func buildECSchedule(c *cli.Context) error {
-	for _, name := range []string{"rules", "template", "cluster"} {
-		if c.String(name) == "" {
-			return fmt.Errorf(`Required flag "%s" not set`, name)
+	// PathFlag は c.Path(), StringFlag は c.String() で取得し、空白のみは未設定として扱う。
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"rules", c.Path("rules")},
+		{"template", c.Path("template")},
+		{"cluster", c.String("cluster")},
+	}
+	for _, f := range required {
+		if strings.TrimSpace(f.value) == "" {
+			return fmt.Errorf(`Required flag "%s" not set`, f.name)
 		}
 	}
 


### PR DESCRIPTION
## 概要

`rules.yaml` を見ただけでは「どのバッチがいつ実行されるか」が分かりにくいため、1 日 24 時間のガントチャートとして HTML に可視化する `gantt` サブコマンドを追加します。

```console
build-ecschedule gantt --rules config/ecschedule.rules.yaml --output ecschedule-gantt.html
```

## 仕様

- **cron(UTC)→ ローカル変換**: cron 式は AWS EventBridge 形式(UTC)としてパースし、表示は `--offset`(既定 9 = JST)で変換。
- **ホバーで詳細**: 各バーに cron / command / 実行時刻 / 条件(日・曜日)/ environment を表示。
- **行の並び**: 実行開始時刻順(`--sort file` で rules.yaml の記述順)。
- **色分け**: command のバイナリ名ごとに色を割当 + 凡例表示。
- 自己完結 HTML(外部依存なし)。

## 変更点

- `cmd/build-ecschedule/gantt.go` — サブコマンド・cron パース・集計
- `cmd/build-ecschedule/gantt_html.go` — HTML 生成
- `cmd/build-ecschedule/main.go` — `gantt` 登録。既存 build(ルート Action)は据え置き。Required な global flag はサブコマンド実行時にも強制されるため、必須チェックを `buildECSchedule` 内に移動。
- `README.md` に gantt の説明を追記、`.gitignore` 追加。

## 確認

- `go build ./...` / `go vet ./...` / `gofmt` OK
- kirei の実データ(132 ルール)をエラーなくパースし、headless Chrome でレイアウトも確認。

## 補足

既存の build コマンドの挙動・出力は変更ありません(root の Required タグを外し Action 内チェックに置換したのみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
