### PR TITLE
improve(gantt): 表示改善と検索・フィルタ・並び替え機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ build-ecschedule is a tool to build ecschedule.yaml ([Songmu/ecschedule: ecsched
 
 - cron 式は AWS EventBridge 形式(UTC)としてパースし、表示は `--offset`(デフォルト 9 = JST)で変換します。
 - 各行はバーにホバーすると cron / command / 実行時刻 / 日・曜日などの条件を表示します。
-- 行は実行開始時刻順に並びます。`--sort file` で rules.yaml の記述順になります。
 - バーの色は command のバイナリ名ごとに割り当てます。
+- 生成された HTML 上では、以下をその場で操作できます(クライアント JS のみ・外部依存なし)。
+  - **検索**: 名前・説明・コマンドで部分一致絞り込み。
+  - **フィルタ**: 凡例(command バイナリ別)のクリックで表示/非表示をトグル。
+  - **並び替え**: 実行時刻順 / バッチ名順 / 記述順。`--sort` は初期値を指定します。
 
 | flag | default | 説明 |
 |------|---------|------|
@@ -28,4 +31,4 @@ build-ecschedule is a tool to build ecschedule.yaml ([Songmu/ecschedule: ecsched
 | `--output` | `ecschedule-gantt.html` | 出力 HTML ファイル |
 | `--offset` | `9` | UTC からのオフセット時間(JST=9) |
 | `--tz` | `JST` | 表示用タイムゾーンラベル |
-| `--sort` | `time` | 行の並び順(`time` = 実行開始時刻順 / `file` = 記述順) |
+| `--sort` | `time` | 初期の行の並び順(`time` = 実行開始時刻順 / `name` = バッチ名順 / `file` = 記述順) |

--- a/cmd/build-ecschedule/gantt.go
+++ b/cmd/build-ecschedule/gantt.go
@@ -23,7 +23,7 @@ var ganttCommand = &cli.Command{
 		&cli.PathFlag{Name: "output", Value: "ecschedule-gantt.html", Usage: "output HTML file"},
 		&cli.IntFlag{Name: "offset", Value: 9, Usage: "timezone offset in hours from UTC (JST=9)"},
 		&cli.StringFlag{Name: "tz", Value: "JST", Usage: "timezone label for display"},
-		&cli.StringFlag{Name: "sort", Value: "time", Usage: "row order: time (first fired time) or file (rules order)"},
+		&cli.StringFlag{Name: "sort", Value: "time", Usage: "initial row order: time (first fired time), name, or file (rules order)"},
 	},
 }
 
@@ -39,7 +39,7 @@ func runGantt(c *cli.Context) error {
 
 	offsetMin := c.Int("offset") * 60
 	rows := make([]ganttRow, 0, len(rules))
-	for _, r := range rules {
+	for i, r := range rules {
 		r.Name = strings.TrimSpace(r.Name)
 		r.Description = strings.TrimSpace(r.Description)
 		r.ScheduleExpression = strings.TrimSpace(r.ScheduleExpression)
@@ -51,15 +51,23 @@ func runGantt(c *cli.Context) error {
 		}
 		minutes := cron.firedMinutes(offsetMin)
 		rows = append(rows, ganttRow{
-			rule:    r,
-			cron:    cron,
-			group:   commandBinary(r.Command),
-			minutes: minutes,
-			runs:    mergeRuns(minutes),
+			rule:      r,
+			cron:      cron,
+			group:     commandBinary(r.Command),
+			minutes:   minutes,
+			runs:      mergeRuns(minutes),
+			fileIndex: i,
 		})
 	}
 
-	if c.String("sort") != "file" {
+	switch c.String("sort") {
+	case "file":
+		// rules.yaml の記述順のまま
+	case "name":
+		sort.SliceStable(rows, func(i, j int) bool {
+			return rows[i].rule.Name < rows[j].rule.Name
+		})
+	default: // "time"
 		sort.SliceStable(rows, func(i, j int) bool {
 			fi, fj := firstOr(rows[i].minutes, 1<<30), firstOr(rows[j].minutes, 1<<30)
 			if fi != fj {
@@ -69,7 +77,11 @@ func runGantt(c *cli.Context) error {
 		})
 	}
 
-	out := renderHTML(rows, c.Int("offset"), c.String("tz"))
+	sortMode := c.String("sort")
+	if sortMode != "name" && sortMode != "file" {
+		sortMode = "time"
+	}
+	out := renderHTML(rows, c.Int("offset"), c.String("tz"), sortMode)
 	if err := os.WriteFile(c.Path("output"), []byte(out), 0600); err != nil {
 		return fmt.Errorf("os.WriteFile(%s) failed: %w", c.Path("output"), err)
 	}
@@ -78,11 +90,12 @@ func runGantt(c *cli.Context) error {
 }
 
 type ganttRow struct {
-	rule    Rule
-	cron    cronExpr
-	group   string
-	minutes []int    // 発火する分(JST, 0..1439)昇順・重複なし
-	runs    [][2]int // 連続区間 [start, end)(0..1440)
+	rule      Rule
+	cron      cronExpr
+	group     string
+	minutes   []int    // 発火する分(JST, 0..1439)昇順・重複なし
+	runs      [][2]int // 連続区間 [start, end)(0..1440)
+	fileIndex int      // rules.yaml 上の記述順
 }
 
 // ---- cron parsing -----------------------------------------------------------

--- a/cmd/build-ecschedule/gantt.go
+++ b/cmd/build-ecschedule/gantt.go
@@ -65,7 +65,8 @@ func runGantt(c *cli.Context) error {
 		// rules.yaml の記述順のまま
 	case "name":
 		sort.SliceStable(rows, func(i, j int) bool {
-			return rows[i].rule.Name < rows[j].rule.Name
+			// HTML 側の並び替え(data-name は小文字化)と順序を揃えるため小文字で比較する
+			return strings.ToLower(rows[i].rule.Name) < strings.ToLower(rows[j].rule.Name)
 		})
 	default: // "time"
 		sort.SliceStable(rows, func(i, j int) bool {
@@ -73,7 +74,7 @@ func runGantt(c *cli.Context) error {
 			if fi != fj {
 				return fi < fj
 			}
-			return rows[i].rule.Name < rows[j].rule.Name
+			return strings.ToLower(rows[i].rule.Name) < strings.ToLower(rows[j].rule.Name)
 		})
 	}
 

--- a/cmd/build-ecschedule/gantt_html.go
+++ b/cmd/build-ecschedule/gantt_html.go
@@ -16,25 +16,29 @@ func renderHTML(rows []ganttRow, offsetHours int, tz string) string {
 <meta charset="utf-8">
 <title>ecschedule gantt</title>
 <style>
-:root { --label-w: 320px; --row-h: 20px; }
+:root { --label-w: 320px; --row-h: 34px; }
 * { box-sizing: border-box; }
 body { margin: 0; font-family: -apple-system, "Helvetica Neue", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif; font-size: 12px; color: #222; }
-header { padding: 12px 16px; border-bottom: 1px solid #ddd; position: sticky; top: 0; background: #fff; z-index: 5; }
+/* ヘッダーと時刻軸をひとつの sticky にまとめ、行がその下にスクロールするようにする
+   (個別 sticky + 固定 top だとヘッダー高とずれて先頭行が隠れるため) */
+.topbar { position: sticky; top: 0; z-index: 5; background: #fff; border-bottom: 1px solid #ccc; }
+header { padding: 12px 16px; }
 header h1 { margin: 0 0 4px; font-size: 15px; }
 header .meta { color: #666; font-size: 11px; }
 .legend { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 4px 12px; }
 .legend span { display: inline-flex; align-items: center; gap: 4px; }
 .legend i { width: 11px; height: 11px; border-radius: 2px; display: inline-block; }
 .chart { padding: 0 16px 40px; }
-.axis { display: flex; position: sticky; top: var(--axis-top, 96px); background: #fff; z-index: 4; border-bottom: 1px solid #ccc; }
+.axis { display: flex; padding: 4px 16px; border-top: 1px solid #eee; }
 .axis .label-pad { width: var(--label-w); flex: none; }
-.axis .ticks { position: relative; flex: 1; height: 20px; }
-.axis .ticks span { position: absolute; transform: translateX(-50%); color: #888; font-size: 10px; top: 4px; }
+.axis .ticks { position: relative; flex: 1; height: 16px; }
+.axis .ticks span { position: absolute; transform: translateX(-50%); color: #888; font-size: 10px; top: 2px; }
 .row { display: flex; align-items: center; height: var(--row-h); border-bottom: 1px solid #f2f2f2; }
 .row:hover { background: #f6fbff; }
 .row.disabled { opacity: .4; }
-.row .label { width: var(--label-w); flex: none; padding-right: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.row .label .desc { color: #999; margin-left: 6px; }
+.row .label { width: var(--label-w); flex: none; padding-right: 8px; display: flex; flex-direction: column; justify-content: center; overflow: hidden; }
+.row .label .name { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.row .label .desc { color: #999; font-size: 10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .track { position: relative; flex: 1; height: 100%;
   background-image: repeating-linear-gradient(to right, #eee 0 1px, transparent 1px calc(100% / 24)); }
 .track svg { display: block; width: 100%; height: 100%; }
@@ -47,7 +51,8 @@ header .meta { color: #666; font-size: 11px; }
 <body>
 `)
 
-	// ヘッダー + 凡例
+	// ヘッダー + 凡例 + 時刻軸を 1 つの sticky(.topbar)にまとめる
+	b.WriteString(`<div class="topbar">`)
 	fmt.Fprintf(&b, "<header><h1>ecschedule 実行スケジュール</h1>")
 	fmt.Fprintf(&b, `<div class="meta">%d ルール / 横軸 = 1 日 24 時間(%s, UTC%+d)。バーにホバーで詳細。日・曜日制約は cron 上は UTC 基準。</div>`,
 		len(rows), html.EscapeString(tz), offsetHours)
@@ -57,8 +62,6 @@ header .meta { color: #666; font-size: 11px; }
 	}
 	b.WriteString(`</div></header>`)
 
-	b.WriteString(`<div class="chart">`)
-
 	// 時刻軸
 	b.WriteString(`<div class="axis"><div class="label-pad"></div><div class="ticks">`)
 	for h := 0; h <= 24; h += 2 {
@@ -66,6 +69,9 @@ header .meta { color: #666; font-size: 11px; }
 		fmt.Fprintf(&b, `<span style="left:%.4f%%">%d</span>`, left, h)
 	}
 	b.WriteString(`</div></div>`)
+	b.WriteString(`</div>`) // .topbar
+
+	b.WriteString(`<div class="chart">`)
 
 	// 各行
 	for _, r := range rows {
@@ -80,7 +86,7 @@ header .meta { color: #666; font-size: 11px; }
 		if r.rule.Disabled {
 			label += " (disabled)"
 		}
-		fmt.Fprintf(&b, `<div class="label">%s<span class="desc">%s</span></div>`,
+		fmt.Fprintf(&b, `<div class="label"><span class="name">%s</span><span class="desc">%s</span></div>`,
 			label, html.EscapeString(r.rule.Description))
 		b.WriteString(`<div class="track"><svg viewBox="0 0 1440 10" preserveAspectRatio="none">`)
 		for _, run := range r.runs {

--- a/cmd/build-ecschedule/gantt_html.go
+++ b/cmd/build-ecschedule/gantt_html.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func renderHTML(rows []ganttRow, offsetHours int, tz string) string {
+func renderHTML(rows []ganttRow, offsetHours int, tz, sortMode string) string {
 	var b strings.Builder
 
 	b.WriteString(`<!DOCTYPE html>
@@ -27,6 +27,8 @@ header h1 { margin: 0 0 4px; font-size: 15px; }
 header .meta { color: #666; font-size: 11px; }
 .toolbar { margin-top: 8px; display: flex; align-items: center; gap: 10px; }
 .toolbar input { width: 320px; max-width: 60vw; padding: 4px 8px; font-size: 12px; border: 1px solid #ccc; border-radius: 4px; }
+.toolbar label { color: #666; font-size: 11px; }
+.toolbar select { font-size: 12px; padding: 3px 4px; }
 .toolbar .count { color: #666; font-size: 11px; }
 .legend { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 4px 12px; }
 .legend span { display: inline-flex; align-items: center; gap: 4px; cursor: pointer; user-select: none; }
@@ -63,6 +65,19 @@ header .meta { color: #666; font-size: 11px; }
 		len(rows), html.EscapeString(tz), offsetHours)
 	b.WriteString(`<div class="toolbar">`)
 	b.WriteString(`<input id="search" type="search" placeholder="名前・説明・コマンドで絞り込み" autocomplete="off">`)
+	b.WriteString(`<label>並び替え <select id="sort">`)
+	for _, opt := range []struct{ val, label string }{
+		{"time", "実行時刻順"},
+		{"name", "バッチ名順"},
+		{"file", "記述順"},
+	} {
+		sel := ""
+		if opt.val == sortMode {
+			sel = " selected"
+		}
+		fmt.Fprintf(&b, `<option value="%s"%s>%s</option>`, opt.val, sel, opt.label)
+	}
+	b.WriteString(`</select></label>`)
 	b.WriteString(`<span class="count" id="count"></span>`)
 	b.WriteString(`</div>`)
 	b.WriteString(`<div class="legend" title="クリックで表示/非表示を切り替え">`)
@@ -81,7 +96,7 @@ header .meta { color: #666; font-size: 11px; }
 	b.WriteString(`</div></div>`)
 	b.WriteString(`</div>`) // .topbar
 
-	b.WriteString(`<div class="chart">`)
+	b.WriteString(`<div class="chart" id="chart">`)
 
 	// 各行
 	for _, r := range rows {
@@ -92,8 +107,10 @@ header .meta { color: #666; font-size: 11px; }
 		}
 		tip := buildTip(r, tz)
 		search := strings.ToLower(r.rule.Name + " " + r.rule.Description + " " + r.rule.Command)
-		fmt.Fprintf(&b, `<div class="%s" data-group="%s" data-search="%s" data-tip="%s">`,
-			cls, html.EscapeString(r.group), html.EscapeString(search), html.EscapeString(tip))
+		fmt.Fprintf(&b, `<div class="%s" data-group="%s" data-search="%s" data-name="%s" data-first="%d" data-index="%d" data-tip="%s">`,
+			cls, html.EscapeString(r.group), html.EscapeString(search),
+			html.EscapeString(strings.ToLower(r.rule.Name)), firstOr(r.minutes, 1<<30), r.fileIndex,
+			html.EscapeString(tip))
 		label := html.EscapeString(r.rule.Name)
 		if r.rule.Disabled {
 			label += " (disabled)"
@@ -139,11 +156,32 @@ header .meta { color: #666; font-size: 11px; }
     row.addEventListener('mouseleave', function(){ tip.style.display = 'none'; });
   });
 
-  // 検索 + 凡例(グループ)フィルタ
+  // 検索 + 凡例(グループ)フィルタ + 並び替え
   var rows = Array.prototype.slice.call(document.querySelectorAll('.row'));
   var search = document.getElementById('search');
   var count = document.getElementById('count');
+  var sortSel = document.getElementById('sort');
+  var chart = document.getElementById('chart');
   var offGroups = {};
+
+  function sortRows(){
+    var mode = sortSel.value;
+    var sorted = rows.slice();
+    sorted.sort(function(a, b){
+      if (mode === 'name') {
+        return a.getAttribute('data-name').localeCompare(b.getAttribute('data-name'));
+      }
+      if (mode === 'file') {
+        return (+a.getAttribute('data-index')) - (+b.getAttribute('data-index'));
+      }
+      // time: 開始時刻 → 名前
+      var d = (+a.getAttribute('data-first')) - (+b.getAttribute('data-first'));
+      if (d !== 0) return d;
+      return a.getAttribute('data-name').localeCompare(b.getAttribute('data-name'));
+    });
+    sorted.forEach(function(row){ chart.appendChild(row); });
+  }
+  sortSel.addEventListener('change', sortRows);
   function apply(){
     var q = (search.value || '').toLowerCase().trim();
     var visible = 0;

--- a/cmd/build-ecschedule/gantt_html.go
+++ b/cmd/build-ecschedule/gantt_html.go
@@ -80,9 +80,9 @@ header .meta { color: #666; font-size: 11px; }
 	b.WriteString(`</select></label>`)
 	b.WriteString(`<span class="count" id="count"></span>`)
 	b.WriteString(`</div>`)
-	b.WriteString(`<div class="legend" title="クリックで表示/非表示を切り替え">`)
+	b.WriteString(`<div class="legend" title="クリック / Enter / Space で表示・非表示を切り替え">`)
 	for _, g := range legendGroups(rows) {
-		fmt.Fprintf(&b, `<span class="lg" data-group="%s"><i style="background:%s"></i>%s</span>`,
+		fmt.Fprintf(&b, `<span class="lg" data-group="%s" role="button" tabindex="0" aria-pressed="true"><i style="background:%s"></i>%s</span>`,
 			html.EscapeString(g), groupColor(g), html.EscapeString(g))
 	}
 	b.WriteString(`</div></header>`)
@@ -162,7 +162,7 @@ header .meta { color: #666; font-size: 11px; }
   var count = document.getElementById('count');
   var sortSel = document.getElementById('sort');
   var chart = document.getElementById('chart');
-  var offGroups = {};
+  var offGroups = Object.create(null); // プロトタイプ汚染を避けるため null プロトタイプ辞書
 
   function sortRows(){
     var mode = sortSel.value;
@@ -196,11 +196,16 @@ header .meta { color: #666; font-size: 11px; }
   }
   search.addEventListener('input', apply);
   document.querySelectorAll('.legend .lg').forEach(function(el){
-    el.addEventListener('click', function(){
+    function toggle(){
       var g = el.getAttribute('data-group');
       offGroups[g] = !offGroups[g];
       el.classList.toggle('off', !!offGroups[g]);
+      el.setAttribute('aria-pressed', offGroups[g] ? 'false' : 'true');
       apply();
+    }
+    el.addEventListener('click', toggle);
+    el.addEventListener('keydown', function(e){
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); }
     });
   });
   apply();

--- a/cmd/build-ecschedule/gantt_html.go
+++ b/cmd/build-ecschedule/gantt_html.go
@@ -25,9 +25,14 @@ body { margin: 0; font-family: -apple-system, "Helvetica Neue", "Hiragino Kaku G
 header { padding: 12px 16px; }
 header h1 { margin: 0 0 4px; font-size: 15px; }
 header .meta { color: #666; font-size: 11px; }
+.toolbar { margin-top: 8px; display: flex; align-items: center; gap: 10px; }
+.toolbar input { width: 320px; max-width: 60vw; padding: 4px 8px; font-size: 12px; border: 1px solid #ccc; border-radius: 4px; }
+.toolbar .count { color: #666; font-size: 11px; }
 .legend { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 4px 12px; }
-.legend span { display: inline-flex; align-items: center; gap: 4px; }
+.legend span { display: inline-flex; align-items: center; gap: 4px; cursor: pointer; user-select: none; }
+.legend span.off { opacity: .35; text-decoration: line-through; }
 .legend i { width: 11px; height: 11px; border-radius: 2px; display: inline-block; }
+.row.hidden { display: none; }
 .chart { padding: 0 16px 40px; }
 .axis { display: flex; padding: 4px 16px; border-top: 1px solid #eee; }
 .axis .label-pad { width: var(--label-w); flex: none; }
@@ -56,9 +61,14 @@ header .meta { color: #666; font-size: 11px; }
 	fmt.Fprintf(&b, "<header><h1>ecschedule 実行スケジュール</h1>")
 	fmt.Fprintf(&b, `<div class="meta">%d ルール / 横軸 = 1 日 24 時間(%s, UTC%+d)。バーにホバーで詳細。日・曜日制約は cron 上は UTC 基準。</div>`,
 		len(rows), html.EscapeString(tz), offsetHours)
-	b.WriteString(`<div class="legend">`)
+	b.WriteString(`<div class="toolbar">`)
+	b.WriteString(`<input id="search" type="search" placeholder="名前・説明・コマンドで絞り込み" autocomplete="off">`)
+	b.WriteString(`<span class="count" id="count"></span>`)
+	b.WriteString(`</div>`)
+	b.WriteString(`<div class="legend" title="クリックで表示/非表示を切り替え">`)
 	for _, g := range legendGroups(rows) {
-		fmt.Fprintf(&b, `<span><i style="background:%s"></i>%s</span>`, groupColor(g), html.EscapeString(g))
+		fmt.Fprintf(&b, `<span class="lg" data-group="%s"><i style="background:%s"></i>%s</span>`,
+			html.EscapeString(g), groupColor(g), html.EscapeString(g))
 	}
 	b.WriteString(`</div></header>`)
 
@@ -81,7 +91,9 @@ header .meta { color: #666; font-size: 11px; }
 			cls += " disabled"
 		}
 		tip := buildTip(r, tz)
-		fmt.Fprintf(&b, `<div class="%s" data-tip="%s">`, cls, html.EscapeString(tip))
+		search := strings.ToLower(r.rule.Name + " " + r.rule.Description + " " + r.rule.Command)
+		fmt.Fprintf(&b, `<div class="%s" data-group="%s" data-search="%s" data-tip="%s">`,
+			cls, html.EscapeString(r.group), html.EscapeString(search), html.EscapeString(tip))
 		label := html.EscapeString(r.rule.Name)
 		if r.rule.Disabled {
 			label += " (disabled)"
@@ -126,6 +138,34 @@ header .meta { color: #666; font-size: 11px; }
     });
     row.addEventListener('mouseleave', function(){ tip.style.display = 'none'; });
   });
+
+  // 検索 + 凡例(グループ)フィルタ
+  var rows = Array.prototype.slice.call(document.querySelectorAll('.row'));
+  var search = document.getElementById('search');
+  var count = document.getElementById('count');
+  var offGroups = {};
+  function apply(){
+    var q = (search.value || '').toLowerCase().trim();
+    var visible = 0;
+    rows.forEach(function(row){
+      var g = row.getAttribute('data-group');
+      var hay = row.getAttribute('data-search') || '';
+      var ok = !offGroups[g] && (q === '' || hay.indexOf(q) >= 0);
+      row.classList.toggle('hidden', !ok);
+      if (ok) visible++;
+    });
+    count.textContent = visible + ' / ' + rows.length + ' 件';
+  }
+  search.addEventListener('input', apply);
+  document.querySelectorAll('.legend .lg').forEach(function(el){
+    el.addEventListener('click', function(){
+      var g = el.getAttribute('data-group');
+      offGroups[g] = !offGroups[g];
+      el.classList.toggle('off', !!offGroups[g]);
+      apply();
+    });
+  });
+  apply();
 })();
 </script>
 </body>


### PR DESCRIPTION
## 概要

`gantt` サブコマンド(#4)に対する追加改善です。生成 HTML の見やすさと操作性を向上させます。

## 変更内容

### 表示の改善
- ヘッダー・凡例・時刻軸を 1 つの sticky(`.topbar`)にまとめ、固定 `top` の magic number に依存しないようにした。これで先頭行が時刻軸の下に隠れる問題を解消。
- 行ラベルをバッチ名(太字)+ 改行して説明(グレー)の 2 段表示に変更。

### 操作機能(クライアント JS のみ・外部依存なし)
- **検索**: 名前・説明・コマンドを対象にした部分一致絞り込み(大小無視)。表示件数も表示。
- **フィルタ**: 凡例(command バイナリ別)のクリックで表示/非表示をトグル。
- **並び替え**: 実行時刻順 / バッチ名順 / 記述順をその場で切替。`--sort` に `name` を追加し初期順も指定可能(Go 側でも name ソート対応 → JS 無効でも初期順は維持)。

## 確認

- `go build ./...` / `go vet ./...` / `gofmt` OK
- kirei の実データ(132 ルール)で生成し、headless Chrome で先頭行表示・2 段ラベル・検索(purge)・バッチ名順ソートを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
